### PR TITLE
Add base view model and relay command infrastructure

### DIFF
--- a/HotPort/Commands/RelayCommand.cs
+++ b/HotPort/Commands/RelayCommand.cs
@@ -1,8 +1,12 @@
 using System;
 using System.Windows.Input;
 
-namespace HotPort.ViewModels
+namespace HotPort.Commands
 {
+    /// <summary>
+    /// A simple <see cref="ICommand"/> implementation that relays Execute and CanExecute
+    /// to provided delegates.
+    /// </summary>
     public class RelayCommand : ICommand
     {
         private readonly Action<object?> execute;

--- a/HotPort/ViewModels/BaseViewModel.cs
+++ b/HotPort/ViewModels/BaseViewModel.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace HotPort.ViewModels
+{
+    /// <summary>
+    /// Provides a base implementation of <see cref="INotifyPropertyChanged"/> for view models.
+    /// </summary>
+    public abstract class BaseViewModel : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>
+        /// Raises the <see cref="PropertyChanged"/> event for the specified property.
+        /// </summary>
+        /// <param name="propertyName">Name of the property. This value is optional and
+        /// will be provided automatically when invoked from compilers that support CallerMemberName.</param>
+        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/HotPort/ViewModels/MainViewModel.cs
+++ b/HotPort/ViewModels/MainViewModel.cs
@@ -1,19 +1,18 @@
 using System;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Input;
 using System.Xml.Linq;
 using HotPort.Properties;
+using HotPort.Commands;
 using Microsoft.Win32;
 using Ookii.Dialogs.Wpf;
 
 namespace HotPort.ViewModels
 {
-    public class MainViewModel : INotifyPropertyChanged
+    public class MainViewModel : BaseViewModel
     {
         private XDocument? propHouse;
         private XDocument? newHouse;
@@ -65,9 +64,6 @@ namespace HotPort.ViewModels
             SelectProposedFileCommand = new RelayCommand(_ => SelectProposedFile());
             SetDefaultDirectoryCommand = new RelayCommand(_ => SetDefaultDirectory());
         }
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 
         private void SelectWorksheet()
         {


### PR DESCRIPTION
## Summary
- Introduce `BaseViewModel` implementing `INotifyPropertyChanged` for common MVVM property notification.
- Move `RelayCommand` into a `Commands` namespace to relay execute/can-execute delegates.
- Refactor `MainViewModel` to inherit from `BaseViewModel` and use the new `RelayCommand`.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d135adfc8832493e170f9e1305115