### PR TITLE
Introduce dialog and message service abstractions

### DIFF
--- a/HotPort.Tests/HotPort.Tests.csproj
+++ b/HotPort.Tests/HotPort.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWPF>false</UseWPF>
+    <IsPackable>false</IsPackable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HotPort\HotPort.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\HotPort\ReferenceProfiles.xml">
+      <Link>ReferenceProfiles.xml</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/HotPort.Tests/MainViewModelTests.cs
+++ b/HotPort.Tests/MainViewModelTests.cs
@@ -1,0 +1,36 @@
+using System.Windows;
+using HotPort.Services;
+using HotPort.ViewModels;
+using Xunit;
+
+namespace HotPort.Tests
+{
+    public class StubFileDialogService : IFileDialogService
+    {
+        public string? OpenFilePath { get; set; }
+        public string? SaveFilePath { get; set; }
+        public string? FolderPath { get; set; }
+        public string? OpenFile(string title, string filter, string? initialDirectory = null) => OpenFilePath;
+        public string? SaveFile(string title, string filter, string? initialDirectory = null, string? fileName = null) => SaveFilePath;
+        public string? SelectFolder() => FolderPath;
+    }
+
+    public class StubMessageService : IMessageService
+    {
+        public void ShowMessage(string message, string caption, MessageBoxButton buttons = MessageBoxButton.OK, MessageBoxImage icon = MessageBoxImage.None)
+        {
+        }
+    }
+
+    public class MainViewModelTests
+    {
+        [Fact]
+        public void SelectWorksheetCommand_UsesFileDialogService()
+        {
+            var fileService = new StubFileDialogService { OpenFilePath = "C\\temp\\test.xlsm" };
+            var vm = new MainViewModel(fileService, new StubMessageService());
+            vm.SelectWorksheetCommand.Execute(null);
+            Assert.Equal("C\\temp\\test.xlsm", vm.ExcelFilePath);
+        }
+    }
+}

--- a/HotPort.sln
+++ b/HotPort.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotPort", "HotPort\HotPort.csproj", "{5C810585-0573-42B7-AB1B-878BB4B0517C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotPort.Tests", "HotPort.Tests\HotPort.Tests.csproj", "{C1EDD98F-E038-445B-899A-00E28B9E79A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,9 +15,13 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5C810585-0573-42B7-AB1B-878BB4B0517C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5C810585-0573-42B7-AB1B-878BB4B0517C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5C810585-0573-42B7-AB1B-878BB4B0517C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5C810585-0573-42B7-AB1B-878BB4B0517C}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {5C810585-0573-42B7-AB1B-878BB4B0517C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {5C810585-0573-42B7-AB1B-878BB4B0517C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {C1EDD98F-E038-445B-899A-00E28B9E79A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C1EDD98F-E038-445B-899A-00E28B9E79A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C1EDD98F-E038-445B-899A-00E28B9E79A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C1EDD98F-E038-445B-899A-00E28B9E79A0}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/HotPort/HotPort.csproj
+++ b/HotPort/HotPort.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>HotREF</AssemblyName>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AssemblyVersion>1.1</AssemblyVersion>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HotPort/Services/FileDialogService.cs
+++ b/HotPort/Services/FileDialogService.cs
@@ -1,0 +1,43 @@
+using Microsoft.Win32;
+using Ookii.Dialogs.Wpf;
+
+namespace HotPort.Services
+{
+    public class FileDialogService : IFileDialogService
+    {
+        public string? OpenFile(string title, string filter, string? initialDirectory = null)
+        {
+            var ofd = new OpenFileDialog
+            {
+                Title = title,
+                Filter = filter
+            };
+            if (!string.IsNullOrEmpty(initialDirectory))
+            {
+                ofd.InitialDirectory = initialDirectory;
+            }
+            return ofd.ShowDialog() == true ? ofd.FileName : null;
+        }
+
+        public string? SaveFile(string title, string filter, string? initialDirectory = null, string? fileName = null)
+        {
+            var sfd = new SaveFileDialog
+            {
+                Title = title,
+                Filter = filter,
+                FileName = fileName
+            };
+            if (!string.IsNullOrEmpty(initialDirectory))
+            {
+                sfd.InitialDirectory = initialDirectory;
+            }
+            return sfd.ShowDialog() == true ? sfd.FileName : null;
+        }
+
+        public string? SelectFolder()
+        {
+            var fbd = new VistaFolderBrowserDialog();
+            return fbd.ShowDialog() == true ? fbd.SelectedPath : null;
+        }
+    }
+}

--- a/HotPort/Services/IFileDialogService.cs
+++ b/HotPort/Services/IFileDialogService.cs
@@ -1,0 +1,9 @@
+namespace HotPort.Services
+{
+    public interface IFileDialogService
+    {
+        string? OpenFile(string title, string filter, string? initialDirectory = null);
+        string? SaveFile(string title, string filter, string? initialDirectory = null, string? fileName = null);
+        string? SelectFolder();
+    }
+}

--- a/HotPort/Services/IMessageService.cs
+++ b/HotPort/Services/IMessageService.cs
@@ -1,0 +1,9 @@
+using System.Windows;
+
+namespace HotPort.Services
+{
+    public interface IMessageService
+    {
+        void ShowMessage(string message, string caption, MessageBoxButton buttons = MessageBoxButton.OK, MessageBoxImage icon = MessageBoxImage.None);
+    }
+}

--- a/HotPort/Services/MessageService.cs
+++ b/HotPort/Services/MessageService.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace HotPort.Services
+{
+    public class MessageService : IMessageService
+    {
+        public void ShowMessage(string message, string caption, MessageBoxButton buttons = MessageBoxButton.OK, MessageBoxImage icon = MessageBoxImage.None)
+        {
+            MessageBox.Show(message, caption, buttons, icon);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IFileDialogService` and `IMessageService` with concrete implementations wrapping file and message dialogs
- Inject new services into `MainViewModel` and replace direct dialog invocations
- Add xUnit tests using stub services and enable Windows targeting for cross-platform builds

## Testing
- `dotnet test HotPort.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689d14ac60a08324b5351b6f4c4a8a82