### PR TITLE
Expose settings via view model

### DIFF
--- a/HotPort/MainWindow.xaml
+++ b/HotPort/MainWindow.xaml
@@ -3,7 +3,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:properties="clr-namespace:HotPort.Properties"
         xmlns:viewModels="clr-namespace:HotPort.ViewModels"
         mc:Ignorable="d"
         Title="HotREF" Height="400" Width="360" WindowStyle="SingleBorderWindow" Closing="Window_Closing" ResizeMode="NoResize">
@@ -22,7 +21,7 @@
         <Button x:Name="WorksheetButton" Content="Select Worksheet" HorizontalAlignment="Center" Margin="0,35,0,0" VerticalAlignment="Top" Width="320" Height="20" Command="{Binding SelectWorksheetCommand}"/>
         <Button x:Name="TemplateButton" Content="Select Template" HorizontalAlignment="Left" Margin="20,31,0,0" VerticalAlignment="Top" Width="190" Grid.Row="1" Height="20" Command="{Binding SelectTemplateCommand}"/>
         <Button x:Name="CreatePropButton" Content="Create Proposed File" HorizontalAlignment="Center" Margin="0,99,0,0" VerticalAlignment="Top" Width="320" Height="20" Grid.Row="1" Command="{Binding CreateProposedFileCommand}"/>
-        <CheckBox x:Name="WindowCheckbox" Content="Include Windows" Grid.Row="1" Margin="230,35,10,76" IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=WindowsCheckbox, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+        <CheckBox x:Name="WindowCheckbox" Content="Include Windows" Grid.Row="1" Margin="230,35,10,76" IsChecked="{Binding WindowsCheckbox, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
         <Button x:Name="CreateRefButton" Content="Create REF" HorizontalAlignment="Center" Width="320" Grid.Row="2" Height="20" VerticalAlignment="Top" Command="{Binding CreateRefCommand}" Margin="0,120,0,0"/>
         <TextBlock x:Name="worksheetTextBlock" HorizontalAlignment="Left" Margin="20,60,0,0" TextWrapping="Wrap" Text="{Binding WorksheetText}" VerticalAlignment="Top" Width="190" RenderTransformOrigin="0.5,0.692"/>
         <Button x:Name="SelectPropFileButton" Content="Select Proposed File" HorizontalAlignment="Left" Margin="20,50,0,0" VerticalAlignment="Top" Width="240" Height="20" Grid.Row="2" Command="{Binding SelectProposedFileCommand}"/>

--- a/HotPort/MainWindow.xaml.cs
+++ b/HotPort/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Windows;
 using HotPort.Properties;
+using HotPort.ViewModels;
 
 namespace HotPort
 {
@@ -33,7 +34,15 @@ namespace HotPort
         {
             Settings.Default.WindowLeft = this.Left;
             Settings.Default.WindowTop = this.Top;
-            Settings.Default.Save();
+
+            if (DataContext is MainViewModel vm && vm.SaveSettingsCommand.CanExecute(null))
+            {
+                vm.SaveSettingsCommand.Execute(null);
+            }
+            else
+            {
+                Settings.Default.Save();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose `TemplateDir` and `WindowsCheckbox` settings as bindable properties
- bind windows checkbox to view model and add command to save settings
- persist settings through view model from window closing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d228cde2c83248cdc5221d60f4924