### PR TITLE
Refactor Excel cell value lookup into shared helper

### DIFF
--- a/HotPort/Models/CreateProp.cs
+++ b/HotPort/Models/CreateProp.cs
@@ -1,12 +1,10 @@
 ﻿//Created by Jesse Russo 2021
-using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Spreadsheet;
-using System.Text.RegularExpressions;
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using HotPort.Services;
 
 namespace HotPort
 {
@@ -881,59 +879,9 @@ namespace HotPort
                 window.Remove();
             }
         }
-        //Method to get the value of single cells from Excel worksheet
-        //Should probably fix this so that the file only opens once
-        public static string GetCellValue(string sheetName, string refCell)
+        private static string GetCellValue(string sheetName, string refCell)
         {
-            string? value = null;
-
-            using (FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-            {
-                using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(fs, false))
-                {
-                    WorkbookPart? wbPart = spreadsheet.WorkbookPart;
-                    Sheet? theSheet = wbPart?.Workbook.Descendants<Sheet>().
-                        Where(s => s.Name == sheetName).FirstOrDefault();
-                    if (theSheet == null)
-                    {
-                        throw new ArgumentException(null, nameof(sheetName));
-                    }
-                    WorksheetPart wsPart = (WorksheetPart)wbPart!.GetPartById(theSheet.Id!);
-
-                    Cell? theCell = wsPart.Worksheet?.Descendants<Cell>()?.
-                        Where(c => c.CellReference == refCell).FirstOrDefault();
-                    if (theCell is null || theCell.InnerText.Length < 0)
-                    {
-                        return string.Empty;
-                    }
-                    value = theCell?.CellValue?.InnerText;
-
-                    if (theCell?.DataType != null)
-                    {
-                        if (theCell.DataType.Value == CellValues.SharedString)
-                        {
-                            var stringTable = wbPart.GetPartsOfType<SharedStringTablePart>().FirstOrDefault();
-                            if (stringTable is not null)
-                            {
-                                value = stringTable.SharedStringTable.ElementAt(int.Parse(value)).InnerText;
-                            }
-                        }
-                        else if (theCell.DataType.Value == CellValues.Boolean)
-                        {
-                            switch (value)
-                            {
-                                case "0":
-                                    value = "FALSE";
-                                    break;
-                                default:
-                                    value = "TRUE";
-                                    break;
-                            }
-                        }
-                    }
-                }
-                fs.Close();
-            }return value;
+            return ExcelHelper.GetCellValue(filePath, sheetName, refCell);
         }
         //stolen regex to separate filename into an address
         static string CamelCaseToSpaceSeparated(string text)

--- a/HotPort/Models/CreateRef.cs
+++ b/HotPort/Models/CreateRef.cs
@@ -3,9 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
-using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Spreadsheet;
-using System.IO;
+using HotPort.Services;
 
 namespace HotPort
 {
@@ -457,58 +455,9 @@ namespace HotPort
             return house;
         }
         //Method to get the value of a single cell from worksheet
-        public string GetCellValue(string sheetName, string refCell)
+        private string GetCellValue(string sheetName, string refCell)
         {
-            string? value = null;
-
-            using (FileStream fs = new FileStream(ExcelFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-            {
-                using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(fs, false))
-                {
-                    WorkbookPart? wbPart = spreadsheet.WorkbookPart;
-                    Sheet? theSheet = wbPart?.Workbook.Descendants<Sheet>().
-                        Where(s => s.Name == sheetName).FirstOrDefault();
-                    if (theSheet == null)
-                    {
-                        throw new ArgumentException("sheetName");
-                    }
-                    WorksheetPart wsPart = (WorksheetPart)wbPart!.GetPartById(theSheet.Id!);
-
-                    Cell? theCell = wsPart.Worksheet?.Descendants<Cell>()?.
-                        Where(c => c.CellReference == refCell).FirstOrDefault();
-                    if (theCell is null || theCell.InnerText.Length < 0)
-                    {
-                        return string.Empty;
-                    }
-                    value = theCell?.CellValue?.InnerText;
-
-                    if (theCell?.DataType != null)
-                    {
-                        if (theCell.DataType.Value == CellValues.SharedString)
-                        {
-                            var stringTable = wbPart.GetPartsOfType<SharedStringTablePart>().FirstOrDefault();
-                            if (stringTable is not null)
-                            {
-                                value = stringTable.SharedStringTable.ElementAt(int.Parse(value)).InnerText;
-                            }
-                        }
-                        else if (theCell.DataType.Value == CellValues.Boolean)
-                        {
-                            switch (value)
-                            {
-                                case "0":
-                                    value = "FALSE";
-                                    break;
-                                default:
-                                    value = "TRUE";
-                                    break;
-                            }
-                        }
-                    }
-
-                }
-            }
-            return value;
+            return ExcelHelper.GetCellValue(ExcelFilePath, sheetName, refCell);
         }
     }
 }

--- a/HotPort/Services/ExcelHelper.cs
+++ b/HotPort/Services/ExcelHelper.cs
@@ -1,0 +1,72 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace HotPort.Services
+{
+    public static class ExcelHelper
+    {
+        private static readonly Dictionary<string, (FileStream Stream, SpreadsheetDocument Document)> _cache = new();
+
+        public static string GetCellValue(string filePath, string sheetName, string cellReference)
+        {
+            var doc = GetDocument(filePath);
+            WorkbookPart? wbPart = doc.WorkbookPart;
+            Sheet? theSheet = wbPart?.Workbook.Descendants<Sheet>()
+                .FirstOrDefault(s => s.Name == sheetName);
+            if (theSheet == null)
+            {
+                throw new ArgumentException(null, nameof(sheetName));
+            }
+            WorksheetPart wsPart = (WorksheetPart)wbPart!.GetPartById(theSheet.Id!);
+            Cell? theCell = wsPart.Worksheet.Descendants<Cell>()
+                .FirstOrDefault(c => c.CellReference == cellReference);
+            if (theCell == null || string.IsNullOrEmpty(theCell.InnerText))
+            {
+                return string.Empty;
+            }
+            string? value = theCell.CellValue?.InnerText;
+            if (theCell.DataType != null)
+            {
+                if (theCell.DataType.Value == CellValues.SharedString)
+                {
+                    var stringTable = wbPart.GetPartsOfType<SharedStringTablePart>().FirstOrDefault();
+                    if (stringTable != null)
+                    {
+                        value = stringTable.SharedStringTable.ElementAt(int.Parse(value)).InnerText;
+                    }
+                }
+                else if (theCell.DataType.Value == CellValues.Boolean)
+                {
+                    value = value == "0" ? "FALSE" : "TRUE";
+                }
+            }
+            return value ?? string.Empty;
+        }
+
+        private static SpreadsheetDocument GetDocument(string filePath)
+        {
+            if (!_cache.TryGetValue(filePath, out var entry))
+            {
+                var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                var document = SpreadsheetDocument.Open(stream, false);
+                entry = (stream, document);
+                _cache[filePath] = entry;
+            }
+            return entry.Document;
+        }
+
+        public static void CloseCachedDocuments()
+        {
+            foreach (var entry in _cache.Values)
+            {
+                entry.Document.Close();
+                entry.Stream.Close();
+            }
+            _cache.Clear();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add shared `ExcelHelper` to read Excel cell values with cached workbook access
- update `CreateProp` and `CreateRef` to delegate cell lookups to `ExcelHelper`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c379b2c48324891b38c06e321b38